### PR TITLE
Limit how often a Todoist sync happens.

### DIFF
--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -604,8 +604,18 @@ function todoistSync(callback)
         syncToken = "*";  // last sync has a different subset; start afresh
     // TODO: Periodically (e.g. every 30d?), do a full sync to clear old state, like deleted tasks.
     let state = {};
-    if (syncToken != "*")
+    if (syncToken != "*") {
         state = JSON.parse(localStorage.getItem("todoistSyncState") || "{}");
+
+        const lastSync = parseInt(localStorage.getItem("todoistLastSync")) || 0;
+        const ageSeconds = (Date.now() - lastSync) / 1000;
+
+        if (ageSeconds < 15) {  // TODO: make configurable
+            // Sync was recent enough; use the state we already have.
+            callback(state);
+            return;
+        }
+    }
 
     // Sync data.
     //console.log("Starting Todoist sync with syncToken=" + syncToken);
@@ -645,6 +655,7 @@ function todoistSync(callback)
         localStorage.setItem("todoistSyncState", JSON.stringify(state));
         localStorage.setItem("todoistSyncToken", data.sync_token);
         localStorage.setItem("todoistSyncRev", "rev1");
+        localStorage.setItem("todoistLastSync", Date.now().toString());
 
         // Call the final callback.
         callback(state);


### PR DESCRIPTION
Data doesn't change most of the time, so polling for updates makes for slow navigation. Limit syncs to only happen when it's been (by default) at least 15 seconds since the prior sync.